### PR TITLE
fix: Change the name of a user in participant

### DIFF
--- a/participantes.txt
+++ b/participantes.txt
@@ -20,6 +20,7 @@ gabo1243
 GonzaloMatus
 GSegov1a
 gustavopalaciosc
+Harold
 IanZmen
 IgnacioM4rtinez
 isufan


### PR DESCRIPTION
### Qué se hizo
- Corrige el cálculo de offset en el sensor IMU BNO055

### Por qué
- El cálculo actual aplicaba una corrección incorrecta a los ejes X y Z

### Cómo probarlo
- Ejecutar el nodo `imu_broadcaster` y observar valores estables al reposo
